### PR TITLE
open index.html via npm start

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ npm install actual --save
 ```
 npm install
 npm test
+npm start
 ```
 
 ## Fund

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "author": "Ryan Van Etten",
   "scripts": {
     "pretest": "eslint .",
-    "start": "open index.html || start index.html",
+    "start": "xdg-open index.html || open index.html || start index.html",
     "test": "node test"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "Ryan Van Etten",
   "scripts": {
     "pretest": "eslint .",
+    "start": "open index.html || start index.html",
     "test": "node test"
   },
   "keywords": [


### PR DESCRIPTION
Use `npm start` as cross platform way to open file in default application

- `xdg-open` for linux
- `open` for mac
- `start` for windows

I tried this in every order on mac and it works fine

```
xdg-open index.html || open index.html || start index.html
```

Responds `command not found` until it reaches the one that opens

I put `xdg-open` first because it seems unlikely that mac or windows would add a cli command named `xdg-open` for different purpose and I put `open` before `start` for same reason